### PR TITLE
refactoring: make the tauri service type-safe by strictly typing the tauri invoke handler and its arguments

### DIFF
--- a/src/app/widgets/notification-history.tsx
+++ b/src/app/widgets/notification-history.tsx
@@ -19,7 +19,7 @@ import { Button, buttonVariants } from "../components/button";
 
 export const NotificationHistory = () => {
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(15);
+  const [pageSize] = useState(15);
   const {
     data: notificationHistory,
     isFetching: isFetchingNotificationHistory,
@@ -48,7 +48,6 @@ export const NotificationHistory = () => {
         notifications={notificationHistory?.notifications ?? []}
       />
       <div className="flex items-center space-x-6 lg:space-x-8 mt-6 justify-center">
-
         <ReactPaginate
           breakLabel="..."
           nextLabel="Next"
@@ -102,7 +101,7 @@ export const NotificationHistory = () => {
             variant="default"
             className="hidden h-8 w-8 p-0 lg:flex"
             onClick={() => setPage(numberOfPages - 1)}
-          // disabled={!table.getCanNextPage()}
+            // disabled={!table.getCanNextPage()}
           >
             <span className="sr-only">Go to last page</span>
             <ChevronsRight />

--- a/src/app/widgets/notifications.tsx
+++ b/src/app/widgets/notifications.tsx
@@ -33,11 +33,20 @@ export const Notifications = (props: {
     index: number;
   }) => {
     const tauriService = new TauriService();
+    const accessToken = sessionService.getAccessToken();
+    if (
+      accessToken === null ||
+      accessToken === "" ||
+      accessToken === undefined
+    ) {
+      console.error("Access token is null or undefined");
+      return;
+    }
 
     tauriService.invoke("read_notification", {
       id,
       index,
-      token: sessionService.getAccessToken(),
+      token: accessToken,
     });
     tauriService.invoke("redirect", {
       url: link,
@@ -50,7 +59,7 @@ export const Notifications = (props: {
 
   const handleRedirectOnEnter = (
     e: React.KeyboardEvent<HTMLLIElement>,
-    redirectProps: Parameters<typeof redirect>[0]
+    redirectProps: Parameters<typeof redirect>[0],
   ) => {
     if (e.key === "Enter") {
       redirect(redirectProps);

--- a/src/core/repositories/notification.repository.ts
+++ b/src/core/repositories/notification.repository.ts
@@ -14,6 +14,15 @@ export default class NotificationRepository {
     const { accessToken } = useSessionStore.getState();
     const { invoke } = this.tauriService;
 
+    if (
+      accessToken === null ||
+      accessToken === "" ||
+      accessToken === undefined
+    ) {
+      console.error("Access token is null or undefined");
+      return [];
+    }
+
     const response = (await invoke("get_latest_notifications", {
       token: accessToken,
     })) as string;
@@ -33,7 +42,7 @@ export default class NotificationRepository {
       };
     };
 
-    return notifications?.data?.notify?.map((notification, index) => {
+    return notifications?.data?.notify?.map((notification) => {
       return new Notification({
         id: notification.id,
         title: notification.title,
@@ -55,6 +64,18 @@ export default class NotificationRepository {
   }> {
     const { accessToken } = useSessionStore.getState();
     const { invoke } = this.tauriService;
+
+    if (
+      accessToken === null ||
+      accessToken === "" ||
+      accessToken === undefined
+    ) {
+      console.error("Access token is null or undefined");
+      return {
+        notifications: [],
+        totalNumberOfNotifications: 0,
+      };
+    }
 
     const response = (await invoke("get_all_notifications", {
       token: accessToken,
@@ -93,7 +114,7 @@ export default class NotificationRepository {
             },
             status: notificationStatus,
           });
-        }
+        },
       ),
       totalNumberOfNotifications: notifications?.data?.total,
     };
@@ -102,7 +123,14 @@ export default class NotificationRepository {
   async getLatestNotificationsCount(): Promise<number> {
     const { accessToken } = useSessionStore.getState();
     const { invoke } = this.tauriService;
-
+    if (
+      accessToken === null ||
+      accessToken === "" ||
+      accessToken === undefined
+    ) {
+      console.error("Access token is null or undefined");
+      return 0;
+    }
     const response = (await invoke("get_latest_notifications_count", {
       token: accessToken,
     })) as string;

--- a/src/core/services/tauri.service.ts
+++ b/src/core/services/tauri.service.ts
@@ -1,28 +1,56 @@
 import { invoke as invokeTauri } from "@tauri-apps/api/core";
 
-const TAURI_COMMANDS = [
-  "authenticate",
-  "notify",
-  "get_latest_notifications",
-  "get_latest_notifications_count",
-  "get_all_notifications",
-  "redirect",
-  "update_tray_icon",
-  "read_notification",
-  "get_user_staff_id",
-  "change_window_size",
-  "center_window",
-] as const;
+type TauriCommandArgs = {
+  authenticate: {
+    username: string;
+    password: string;
+  };
+  notify: {
+    message: string;
+    redirect?: string;
+  };
+  read_notification: {
+    token: string;
+    id: string;
+    index: number;
+  };
+  get_latest_notifications: {
+    token: string;
+  };
+  get_latest_notifications_count: {
+    token: string;
+  };
+  get_all_notifications: {
+    token: string;
+    page: number;
+  };
+  redirect: {
+    url: string;
+  };
+  get_user_staff_id: {
+    token: string;
+  };
+  change_window_size: {
+    width: number;
+    height: number;
+  };
+  center_window: {};
+  update_tray_icon: {
+    rgba: number[];
+    width: number;
+    height: number;
+  };
+};
 
-type TauriCommand = (typeof TAURI_COMMANDS)[number];
+type TauriCommand = keyof TauriCommandArgs;
 
 interface ITauriService {
   invoke: (command: TauriCommand, args: object) => unknown;
 }
 
 export default class TauriService implements ITauriService {
-  async invoke(command: TauriCommand, args: object) {
-    return await invokeTauri(command, {
+  async invoke<T extends TauriCommand>(command: T, args: TauriCommandArgs[T]) {
+    return await invokeTauri(command as string, {
       ...args,
     });
   }

--- a/src/core/services/user.service.ts
+++ b/src/core/services/user.service.ts
@@ -23,10 +23,20 @@ class UserService {
   async getUserStaffId(): Promise<string> {
     const sessionService = new SessionService();
     const { invoke } = this.tauriService;
+    const accessToken = sessionService.getAccessToken();
 
+    if (
+      accessToken === null ||
+      accessToken === "" ||
+      accessToken === undefined
+    ) {
+      console.error("Access token is null or undefined");
+      return "";
+    }
     const response = (await invoke("get_user_staff_id", {
-      token: sessionService.getAccessToken(),
+      token: accessToken,
     })) as string;
+
     const json = JSON.parse(response) as {
       data: {
         username: string;


### PR DESCRIPTION
Made the Tauri service type-safe by strictly typing the invoke handler and its arguments